### PR TITLE
Tito duplicate check fix

### DIFF
--- a/__tests__/titoBulkCreateInvitations.test.ts
+++ b/__tests__/titoBulkCreateInvitations.test.ts
@@ -51,7 +51,7 @@ beforeEach(() => {
   });
 });
 
-test('reuses existing invitation URL on duplicate ticket error', async () => {
+test('reuses preloaded invitation URL and skips create for that applicant', async () => {
   mockedCreate.mockResolvedValueOnce({
     ok: true,
     body: { unique_url: 'url-2' },
@@ -61,8 +61,16 @@ test('reuses existing invitation URL on duplicate ticket error', async () => {
     new Map([['ada@example.com', 'url-existing']])
   );
 
+  const spacedApplicants = [
+    {
+      ...applicants[0],
+      email: '  ada@example.com  ',
+    },
+    applicants[1],
+  ];
+
   const result = await bulkCreateInvitations({
-    applicants: applicants as any,
+    applicants: spacedApplicants as any,
     rsvpListSlug: 'rsvp-1',
     releaseIds: '1',
   });

--- a/__tests__/titoBulkCreateInvitations.test.ts
+++ b/__tests__/titoBulkCreateInvitations.test.ts
@@ -11,18 +11,18 @@ jest.mock('@utils/tito/deleteRsvpInvitationByEmail', () => ({
   default: jest.fn(),
 }));
 
-jest.mock('@utils/tito/getRsvpInvitationByEmail', () => ({
+jest.mock('@utils/tito/getRsvpInvitationsMap', () => ({
   __esModule: true,
-  default: jest.fn(),
+  getRsvpInvitationsMap: jest.fn(),
 }));
 
 import createRsvpInvitation from '@utils/tito/createRsvpInvitation';
 import deleteRsvpInvitationByEmail from '@utils/tito/deleteRsvpInvitationByEmail';
-import getRsvpInvitationByEmail from '@utils/tito/getRsvpInvitationByEmail';
+import { getRsvpInvitationsMap } from '@utils/tito/getRsvpInvitationsMap';
 
 const mockedCreate = createRsvpInvitation as jest.Mock;
 const mockedDeleteByEmail = deleteRsvpInvitationByEmail as jest.Mock;
-const mockedGetByEmail = getRsvpInvitationByEmail as jest.Mock;
+const mockedGetInviteMap = getRsvpInvitationsMap as jest.Mock;
 
 const applicants = [
   {
@@ -43,36 +43,23 @@ const applicants = [
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockedGetInviteMap.mockResolvedValue(new Map());
   mockedDeleteByEmail.mockResolvedValue({
     ok: false,
     deletedInvitationSlug: null,
     error: 'not called',
   });
-  mockedGetByEmail.mockResolvedValue({
-    ok: false,
-    invitation: null,
-    error: 'not called',
-  });
 });
 
 test('reuses existing invitation URL on duplicate ticket error', async () => {
-  mockedCreate
-    .mockResolvedValueOnce({
-      ok: false,
-      body: null,
-      error: 'email has already been taken',
-    })
-    .mockResolvedValueOnce({ ok: true, body: { unique_url: 'url-2' } });
-
-  mockedGetByEmail.mockResolvedValueOnce({
+  mockedCreate.mockResolvedValueOnce({
     ok: true,
-    invitation: {
-      slug: 'rsvp_existing_123',
-      email: 'ada@example.com',
-      unique_url: 'url-existing',
-    },
-    error: null,
+    body: { unique_url: 'url-2' },
   });
+
+  mockedGetInviteMap.mockResolvedValueOnce(
+    new Map([['ada@example.com', 'url-existing']])
+  );
 
   const result = await bulkCreateInvitations({
     applicants: applicants as any,
@@ -80,12 +67,14 @@ test('reuses existing invitation URL on duplicate ticket error', async () => {
     releaseIds: '1',
   });
 
-  expect(mockedGetByEmail).toHaveBeenCalledWith({
-    rsvpListSlug: 'rsvp-1',
-    email: 'ada@example.com',
-  });
+  expect(mockedGetInviteMap).toHaveBeenCalledWith('rsvp-1');
+  expect(mockedCreate).toHaveBeenCalledTimes(1);
+  expect(mockedCreate).toHaveBeenCalledWith(
+    expect.objectContaining({ email: 'grace@example.com' })
+  );
   expect(mockedDeleteByEmail).not.toHaveBeenCalled();
   expect(result.inviteMap.get('ada@example.com')).toBe('url-existing');
+  expect(result.inviteMap.get('grace@example.com')).toBe('url-2');
   expect(result.autoFixedCount).toBe(1);
   expect(result.autoFixedNotesMap['ada@example.com']).toMatch(/reused/i);
 });

--- a/app/(api)/_utils/tito/bulkCreateInvitations.ts
+++ b/app/(api)/_utils/tito/bulkCreateInvitations.ts
@@ -5,6 +5,10 @@ import deleteRsvpInvitationByEmail from './deleteRsvpInvitationByEmail';
 import { BulkInvitationParams, BulkInvitationResult } from '@/app/_types/tito';
 import { getRsvpInvitationsMap } from './getRsvpInvitationsMap';
 
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
 function isDuplicateTicketError(error: string | null | undefined): boolean {
   if (!error) return false;
   const normalized = error.toLowerCase();
@@ -39,7 +43,7 @@ export default async function bulkCreateInvitations(
   let queuedForCreateCount = 0;
 
   const uniqueApplicants = applicants.filter((app) => {
-    const normalizedEmail = app.email.toLowerCase().trim();
+    const normalizedEmail = normalizeEmail(app.email);
     if (seenEmails.has(normalizedEmail)) {
       errors.push(
         `${app.email}: skipped duplicate applicant email in finalize batch`
@@ -52,14 +56,18 @@ export default async function bulkCreateInvitations(
 
   try {
     preloadedInviteMap = await getRsvpInvitationsMap(rsvpListSlug);
-  } catch {
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(
+      `[Bulk Tito] Failed to preload RSVP invitations for ${rsvpListSlug}: ${message}`
+    );
     preloadedInviteMap = new Map<string, string>();
   }
 
   const applicantsToCreate: typeof uniqueApplicants = [];
 
   for (const app of uniqueApplicants) {
-    const normalizedEmail = app.email.toLowerCase();
+    const normalizedEmail = normalizeEmail(app.email);
     const existingInviteUrl = preloadedInviteMap.get(normalizedEmail);
 
     if (existingInviteUrl) {
@@ -107,7 +115,7 @@ export default async function bulkCreateInvitations(
       try {
         const result = batchResults[j];
         const app = batch[j];
-        const normalizedEmail = app.email.toLowerCase();
+        const normalizedEmail = normalizeEmail(app.email);
 
         if (
           result.status === 'fulfilled' &&
@@ -150,12 +158,9 @@ export default async function bulkCreateInvitations(
             });
 
             if (retryResult.ok && retryResult.body?.unique_url) {
-              inviteMap.set(
-                app.email.toLowerCase(),
-                retryResult.body.unique_url
-              );
+              inviteMap.set(normalizedEmail, retryResult.body.unique_url);
               autoFixedCount += 1;
-              autoFixedNotesMap[app.email.toLowerCase()] =
+              autoFixedNotesMap[normalizedEmail] =
                 'A new Tito invite was generated due to duplication.';
               continue;
             }

--- a/app/(api)/_utils/tito/bulkCreateInvitations.ts
+++ b/app/(api)/_utils/tito/bulkCreateInvitations.ts
@@ -2,8 +2,8 @@
 
 import createRsvpInvitation from './createRsvpInvitation';
 import deleteRsvpInvitationByEmail from './deleteRsvpInvitationByEmail';
-import getRsvpInvitationByEmail from './getRsvpInvitationByEmail';
 import { BulkInvitationParams, BulkInvitationResult } from '@/app/_types/tito';
+import { getRsvpInvitationsMap } from './getRsvpInvitationsMap';
 
 function isDuplicateTicketError(error: string | null | undefined): boolean {
   if (!error) return false;
@@ -34,6 +34,9 @@ export default async function bulkCreateInvitations(
   const autoFixedNotesMap: Record<string, string> = {};
   const CONCURRENCY = 20;
   const seenEmails = new Set<string>();
+  let preloadedInviteMap = new Map<string, string>();
+  let skippedFromCreateCount = 0;
+  let queuedForCreateCount = 0;
 
   const uniqueApplicants = applicants.filter((app) => {
     const normalizedEmail = app.email.toLowerCase().trim();
@@ -47,8 +50,43 @@ export default async function bulkCreateInvitations(
     return true;
   });
 
-  for (let i = 0; i < uniqueApplicants.length; i += CONCURRENCY) {
-    const batch = uniqueApplicants.slice(i, i + CONCURRENCY);
+  try {
+    preloadedInviteMap = await getRsvpInvitationsMap(rsvpListSlug);
+  } catch {
+    preloadedInviteMap = new Map<string, string>();
+  }
+
+  const applicantsToCreate: typeof uniqueApplicants = [];
+
+  for (const app of uniqueApplicants) {
+    const normalizedEmail = app.email.toLowerCase();
+    const existingInviteUrl = preloadedInviteMap.get(normalizedEmail);
+
+    if (existingInviteUrl) {
+      skippedFromCreateCount += 1;
+      console.log(
+        `[Bulk Tito] Pre-pulled invite for ${normalizedEmail}; skipping Tito create`
+      );
+      inviteMap.set(normalizedEmail, existingInviteUrl);
+      autoFixedCount += 1;
+      autoFixedNotesMap[normalizedEmail] =
+        'Existing Tito invite was reused due to duplicate email.';
+      continue;
+    }
+
+    queuedForCreateCount += 1;
+    console.log(
+      `[Bulk Tito] No pre-pulled invite for ${normalizedEmail}; will create in Tito`
+    );
+    applicantsToCreate.push(app);
+  }
+
+  console.log(
+    `[Bulk Tito] Pre-pull summary: skipped=${skippedFromCreateCount}, create=${queuedForCreateCount}`
+  );
+
+  for (let i = 0; i < applicantsToCreate.length; i += CONCURRENCY) {
+    const batch = applicantsToCreate.slice(i, i + CONCURRENCY);
 
     // Process the batch with concurrency
     const batchResults = await Promise.allSettled(
@@ -66,99 +104,92 @@ export default async function bulkCreateInvitations(
 
     // Handle results and recovery logic
     for (let j = 0; j < batchResults.length; j++) {
-      const result = batchResults[j];
-      const app = batch[j];
-      const normalizedEmail = app.email.toLowerCase();
+      try {
+        const result = batchResults[j];
+        const app = batch[j];
+        const normalizedEmail = app.email.toLowerCase();
 
-      if (
-        result.status === 'fulfilled' &&
-        result.value.ok &&
-        result.value.body?.unique_url
-      ) {
-        inviteMap.set(normalizedEmail, result.value.body.unique_url);
-        continue;
-      }
-
-      const createError =
-        result.status === 'fulfilled'
-          ? result.value.error
-          : result.reason?.message;
-
-      // Recovery logic for duplicate ticket errors
-      if (isDuplicateTicketError(createError)) {
-        console.warn(
-          `[Bulk Tito] Duplicate ticket detected for ${app.email}. Attempting to reuse existing invite URL before delete + retry.`
-        );
-
-        const existingInviteResult = await getRsvpInvitationByEmail({
-          rsvpListSlug,
-          email: app.email,
-        });
-
-        if (existingInviteResult.ok && existingInviteResult.invitation) {
-          const existingInviteUrl =
-            existingInviteResult.invitation.unique_url ||
-            existingInviteResult.invitation.url;
-
-          if (existingInviteUrl) {
-            inviteMap.set(app.email.toLowerCase(), existingInviteUrl);
-            autoFixedCount += 1;
-            autoFixedNotesMap[app.email.toLowerCase()] =
-              'Existing Tito invite was reused due to duplicate email.';
-            continue;
-          }
-        }
-
-        const deleteResult = await deleteRsvpInvitationByEmail({
-          rsvpListSlug,
-          email: app.email,
-        });
-
-        if (deleteResult.ok) {
-          const retryResult = await createRsvpInvitation({
-            firstName: app.firstName,
-            lastName: app.lastName,
-            email: app.email,
-            rsvpListSlug,
-            releaseIds,
-            discountCode,
-          });
-
-          if (retryResult.ok && retryResult.body?.unique_url) {
-            inviteMap.set(app.email.toLowerCase(), retryResult.body.unique_url);
-            autoFixedCount += 1;
-            autoFixedNotesMap[app.email.toLowerCase()] =
-              'A new Tito invite was generated due to duplication.';
-            continue;
-          }
-
-          const retryErrorMsg = `${
-            app.email
-          }: retry failed after deleting existing Tito invitation (${
-            retryResult.error ?? 'No URL returned'
-          })`;
-          errors.push(retryErrorMsg);
-          console.error(`[Bulk Tito] Failed: ${retryErrorMsg}`);
+        if (
+          result.status === 'fulfilled' &&
+          result.value.ok &&
+          result.value.body?.unique_url
+        ) {
+          inviteMap.set(normalizedEmail, result.value.body.unique_url);
           continue;
         }
 
-        const finalErrorMsg = `${app.email}: duplicate ticket recovery failed (${deleteResult.error})`;
-        errors.push(finalErrorMsg);
-        console.error(`[Bulk Tito] Failed: ${finalErrorMsg}`);
-        continue;
+        const createError =
+          result.status === 'fulfilled'
+            ? result.value.error
+            : result.reason?.message;
+
+        // Recovery logic for duplicate ticket errors
+        if (isDuplicateTicketError(createError)) {
+          const existingInviteUrl = preloadedInviteMap.get(normalizedEmail);
+          if (existingInviteUrl) {
+            inviteMap.set(normalizedEmail, existingInviteUrl);
+            autoFixedCount += 1;
+            autoFixedNotesMap[normalizedEmail] =
+              'Existing Tito invite was reused due to duplicate email.';
+            continue;
+          }
+
+          const deleteResult = await deleteRsvpInvitationByEmail({
+            rsvpListSlug,
+            email: app.email,
+          });
+
+          if (deleteResult.ok) {
+            const retryResult = await createRsvpInvitation({
+              firstName: app.firstName,
+              lastName: app.lastName,
+              email: app.email,
+              rsvpListSlug,
+              releaseIds,
+              discountCode,
+            });
+
+            if (retryResult.ok && retryResult.body?.unique_url) {
+              inviteMap.set(
+                app.email.toLowerCase(),
+                retryResult.body.unique_url
+              );
+              autoFixedCount += 1;
+              autoFixedNotesMap[app.email.toLowerCase()] =
+                'A new Tito invite was generated due to duplication.';
+              continue;
+            }
+
+            const retryErrorMsg = `${
+              app.email
+            }: retry failed after deleting existing Tito invitation (${
+              retryResult.error ?? 'No URL returned'
+            })`;
+            errors.push(retryErrorMsg);
+            console.error(`[Bulk Tito] Failed: ${retryErrorMsg}`);
+            continue;
+          }
+
+          const finalErrorMsg = `${app.email}: duplicate ticket recovery failed (${deleteResult.error})`;
+          errors.push(finalErrorMsg);
+          console.error(`[Bulk Tito] Failed: ${finalErrorMsg}`);
+          continue;
+        }
+        const errorMsg = `${app.email}: ${createError || 'Unknown Error'}`;
+        errors.push(errorMsg);
+        console.error(`[Bulk Tito] Failed: ${errorMsg}`);
+      } catch (error: any) {
+        const app = batch[j];
+        const unexpectedError = `${
+          app.email
+        }: unexpected Tito processing error (${error?.message ?? error})`;
+        errors.push(unexpectedError);
+        console.error(`[Bulk Tito] Failed: ${unexpectedError}`);
       }
-      const errorMsg = `${app.email}: ${createError || 'Unknown Error'}`;
-      errors.push(errorMsg);
-      console.error(`[Bulk Tito] Failed: ${errorMsg}`);
     }
   }
 
   const successCount = inviteMap.size;
-  const failureCount = errors.length;
-
-  console.log(
-    `[Bulk Tito] Complete: ${successCount} succeeded, ${failureCount} failed`
-  );
 
   return {
     ok: successCount > 0,

--- a/app/(api)/_utils/tito/getRsvpInvitationsMap.ts
+++ b/app/(api)/_utils/tito/getRsvpInvitationsMap.ts
@@ -1,0 +1,41 @@
+'use server';
+
+import { TitoRequest } from './titoClient';
+import { TitoReleaseInvitation } from '@/app/_types/tito';
+
+export async function getRsvpInvitationsMap(
+  rsvpListSlug: string
+): Promise<Map<string, string>> {
+  if (!rsvpListSlug?.trim()) {
+    throw new Error('RSVP list slug is required');
+  }
+
+  const pageSize = 1000;
+  let page = 1;
+  let hasMore = true;
+  const inviteMap = new Map<string, string>();
+
+  while (hasMore) {
+    const url = `/rsvp_lists/${rsvpListSlug}/release_invitations?page[size]=${pageSize}&page[number]=${page}`;
+    const data = await TitoRequest<{
+      release_invitations: TitoReleaseInvitation[];
+    }>(url);
+
+    const invitations = data.release_invitations ?? [];
+
+    for (const invitation of invitations) {
+      const email = invitation.email?.trim().toLowerCase();
+      const inviteUrl = invitation.unique_url || invitation.url;
+      if (!email || !inviteUrl) continue;
+
+      if (!inviteMap.has(email)) {
+        inviteMap.set(email, inviteUrl);
+      }
+    }
+
+    hasMore = invitations.length === pageSize;
+    page += 1;
+  }
+
+  return inviteMap;
+}


### PR DESCRIPTION
Current code:
Tito req made -> throws error of duplicate -> do retry

Fix:
Gets a list of pre-existing invites. 
This list of preloaded invites are used to skip known existing invites, only sending requests for those that don't have invites.
This leads to fewer unnecessary Tito requests and less risk of hitting the 300s request limit.
